### PR TITLE
ChatJOEPT edited auditor.ts: the auditor was long since discontinued, it's supposed to save a log of whatever actions are coming in. We are using redis now, which you can import from '.redis' and it would be nice to have the auditor functioning with redis

### DIFF
--- a/api/src/modules/auditor.ts
+++ b/api/src/modules/auditor.ts
@@ -1,4 +1,3 @@
-
 // export default async function auditRequest(props: ): Promise<void> {
 
 //   const { event, db } = props;
@@ -13,4 +12,13 @@
 
 // }
 
-export default {}
+import { redis } from "./redis";
+
+const auditor = (action: any) => {
+  redis.lpush("audit-log", JSON.stringify(action));
+};
+
+export default {
+  ...{},
+  auditor,
+};


### PR DESCRIPTION
GPT: 
Added redis import statement and modified the default export statement to include the auditor functionality using redis.

The modified subset of keys: statement_0
